### PR TITLE
Support for the Llama3.2-1B

### DIFF
--- a/swiftllm/server/api_server.py
+++ b/swiftllm/server/api_server.py
@@ -21,22 +21,52 @@ async def generate(req: fastapi.Request) -> fastapi.Response:
     The request should be a JSON object with fields that match the `RawRequest`
     class plus the following fields:
     - `stream`: boolean, whether to stream the output or not
+    - `decode`: boolean, whether to decode the output tokens (default: True)
     """
     req_dict = await req.json()
     raw_request = swiftllm.RawRequest(
         prompt = req_dict["prompt"],
         output_len = req_dict["output_len"]
     )
+    # Whether to decode the output
+    decode_output = req_dict.get("decode", False)
 
     if req_dict.get("stream", False):
         generator = engine.add_request_and_stream(raw_request)
         async def wrapper():
             output_token_ids = []
+            prev_decoded = ""
+            
             async for step_output in generator:
-                output_token_ids.append(step_output.token_id)
-                # yield f"{step_output.token_id}\n"
-                decoded = await engine.tokenization_engine.decode.remote(output_token_ids, skip_special_tokens=True)
-                yield f"{decoded}\n"
+                token_id = step_output.token_id
+                output_token_ids.append(token_id)
+                
+                if decode_output:
+                    # Only decode new tokens
+                    try:
+                        # Decode current token individually
+                        new_token = await engine.tokenization_engine.decode.remote([token_id], skip_special_tokens=False)
+                        # Handle special case: some tokens need context from previous token
+                        if not new_token and len(output_token_ids) > 1:
+                            # Try decoding last two tokens
+                            last_two = await engine.tokenization_engine.decode.remote(
+                                output_token_ids[-2:], skip_special_tokens=False
+                            )
+                            # Extract new content from combined result
+                            if last_two and len(last_two) > len(prev_decoded):
+                                new_token = last_two[len(prev_decoded):]
+                        
+                        prev_decoded += new_token
+                        yield f"{prev_decoded}\n"
+                    except Exception:
+                        # Fallback to full decoding if incremental fails
+                        decoded = await engine.tokenization_engine.decode.remote(output_token_ids, skip_special_tokens=True)
+                        prev_decoded = decoded
+                        yield f"{decoded}\n"
+                else:
+                    # Output token ID without decoding
+                    yield f"{token_id}\n"
+        
         return fastapi.responses.StreamingResponse(
             wrapper(),
             media_type="text/plain"
@@ -44,13 +74,14 @@ async def generate(req: fastapi.Request) -> fastapi.Response:
     else:
         # TODO Abort the request when the client disconnects
         (_, output_token_ids) = await engine.add_request_and_wait(raw_request)
-        decoded = await engine.tokenization_engine.decode.remote(output_token_ids, skip_special_tokens=True)
-        return fastapi.responses.JSONResponse(
-            content={"output": decoded, "output_token_ids": output_token_ids}
-        )
-        # return fastapi.responses.JSONResponse(
-        #     content={"output_token_ids": output_token_ids}
-        # )
+        
+        response_content = {"output_token_ids": output_token_ids}
+        
+        if decode_output:
+            decoded = await engine.tokenization_engine.decode.remote(output_token_ids, skip_special_tokens=True)
+            response_content["output"] = decoded
+        
+        return fastapi.responses.JSONResponse(content=response_content)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/swiftllm/server/tokenization_engine.py
+++ b/swiftllm/server/tokenization_engine.py
@@ -11,3 +11,6 @@ class TokenizationEngine:
     def batched_tokenize(self, prompts: list[str]) -> list[list[int]]:
         prompt_token_ids = self.tokenizer(prompts, return_attention_mask=False)['input_ids']
         return prompt_token_ids
+
+    def decode(self, token_ids: list[int], skip_special_tokens: bool = True) -> str:
+        return self.tokenizer.decode(token_ids, skip_special_tokens=skip_special_tokens)

--- a/swiftllm/worker/kernels/block_mgmt.py
+++ b/swiftllm/worker/kernels/block_mgmt.py
@@ -112,6 +112,8 @@ def gather_allocated_blocks_and_unset(
     """
     Gather the block IDs allocated for the specified sequences and mark them as free
     """
+    if seq_ids.numel() == 0:
+        return torch.empty((0,), dtype=torch.int32, device=block_table.device)
     num_allocated_blocks_cumsum = torch.cumsum(num_seq_allocated_blocks[seq_ids], 0)
     gathered_block_ids = torch.empty((num_allocated_blocks_cumsum[-1].item(),), dtype=torch.int32, device=block_table.device)
 

--- a/swiftllm/worker/model.py
+++ b/swiftllm/worker/model.py
@@ -181,14 +181,14 @@ class LlamaModel:
 
         # Handle the case where rope_scaling is a dictionary (Llama 3.2)
         if isinstance(rope_scaling, dict):
-            scaling_factor = rope_scaling.get('factor', 1.0)
+            scaling_factor = rope_scaling.get('factor', 4.0)
             low_freq_factor = rope_scaling.get('low_freq_factor', 1.0)
             high_freq_factor = rope_scaling.get('high_freq_factor', 1.0)
             rope_type = rope_scaling.get('rope_type', 'llama3')
             original_max_position_embeddings = rope_scaling.get('original_max_position_embeddings', max_position_embeddings)
 
             # Calculate maximum sequence length based on scaling factor
-            max_seq_len = max_position_embeddings * scaling_factor
+            max_seq_len = int(original_max_position_embeddings * scaling_factor)
 
             # Generate position indices
             dim = self.model_config.head_dim

--- a/swiftllm/worker/model.py
+++ b/swiftllm/worker/model.py
@@ -175,14 +175,51 @@ class LlamaModel:
         )
 
     def _init_to_get_rotary(self):
-        rope_scaling_factor = self.model_config.rope_scaling
+        rope_scaling = self.model_config.rope_scaling
         base = self.model_config.rope_theta
         max_position_embeddings = self.model_config.max_position_embeddings
-        max_seq_len = max_position_embeddings * rope_scaling_factor
 
-        inv_freq = 1.0 / (base ** (torch.arange(0, self.model_config.head_dim, 2, device="cuda", dtype=torch.float32) / self.model_config.head_dim))
-        t = torch.arange(max_seq_len + 128, device="cuda", dtype=torch.float32) / rope_scaling_factor
-        freqs = torch.outer(t, inv_freq)
+        # Handle the case where rope_scaling is a dictionary (Llama 3.2)
+        if isinstance(rope_scaling, dict):
+            scaling_factor = rope_scaling.get('factor', 1.0)
+            low_freq_factor = rope_scaling.get('low_freq_factor', 1.0)
+            high_freq_factor = rope_scaling.get('high_freq_factor', 1.0)
+            rope_type = rope_scaling.get('rope_type', 'llama3')
+            original_max_position_embeddings = rope_scaling.get('original_max_position_embeddings', max_position_embeddings)
+
+            # Calculate maximum sequence length based on scaling factor
+            max_seq_len = max_position_embeddings * scaling_factor
+
+            # Generate position indices
+            dim = self.model_config.head_dim
+            t = torch.arange(max_seq_len + 128, device="cuda", dtype=torch.float32)
+
+            # Create frequency array with dimensions split between low and high frequency parts
+            dim_half = dim // 2
+            split_point = int(dim_half * low_freq_factor / (low_freq_factor + high_freq_factor))
+
+            # Apply different scaling factors to different parts of the frequency spectrum
+            inv_freq_low = 1.0 / (base ** (torch.arange(0, split_point * 2, 2, device="cuda", dtype=torch.float32) / dim))
+            inv_freq_high = 1.0 / (base ** (torch.arange(split_point * 2, dim, 2, device="cuda", dtype=torch.float32) / dim))
+
+            # Apply scaling factors
+            low_positions = t / low_freq_factor
+            high_positions = t / high_freq_factor
+
+            # Calculate frequencies for both parts
+            freqs_low = torch.outer(low_positions, inv_freq_low)
+            freqs_high = torch.outer(high_positions, inv_freq_high)
+
+            # Combine frequencies
+            freqs = torch.cat([freqs_low, freqs_high], dim=-1)
+        else:
+            # Original implementation for scalar rope_scaling
+            rope_scaling_factor = rope_scaling
+            max_seq_len = max_position_embeddings * rope_scaling_factor
+
+            inv_freq = 1.0 / (base ** (torch.arange(0, self.model_config.head_dim, 2, device="cuda", dtype=torch.float32) / self.model_config.head_dim))
+            t = torch.arange(max_seq_len + 128, device="cuda", dtype=torch.float32) / rope_scaling_factor
+            freqs = torch.outer(t, inv_freq)
 
         self._cos_cached = torch.cos(freqs).to(torch.float16)
         self._sin_cached = torch.sin(freqs).to(torch.float16)

--- a/swiftllm/worker/weight.py
+++ b/swiftllm/worker/weight.py
@@ -149,9 +149,17 @@ class LlamaWeight(WeightBase):
             (self.model_config.vocab_size, self.model_config.hidden_size),
             self.dtype
         ))
+        # Llama 1~3
+        # self.register_weight(RegisteredWeightItem(
+        #     "lm_head",
+        #     "lm_head.weight",
+        #     (self.model_config.vocab_size, self.model_config.hidden_size),
+        #     self.dtype
+        # ))
+        # Llama 3.1+
         self.register_weight(RegisteredWeightItem(
             "lm_head",
-            "lm_head.weight",
+            "model.embed_tokens.weight",
             (self.model_config.vocab_size, self.model_config.hidden_size),
             self.dtype
         ))

--- a/swiftllm/worker/weight.py
+++ b/swiftllm/worker/weight.py
@@ -60,13 +60,15 @@ class LlamaTransformerLayerWeight(WeightBase):
         self,
         layer_id: int,
         model_config: LlamaModelConfig,
-        dtype: torch.dtype
+        dtype: torch.dtype,
+        model_version: str = "llama"
     ):
         super().__init__()
 
         self.layer_id = layer_id
         self.model_config = model_config
         self.dtype = dtype
+        self.model_version = model_version
 
         self.register_weight(RegisteredWeightItem(
             "attn_norm",
@@ -136,12 +138,14 @@ class LlamaWeight(WeightBase):
     def __init__(
         self,
         model_config: LlamaModelConfig,
-        dtype: torch.dtype
+        dtype: torch.dtype,
+        model_version: str = "llama"
     ):
         super().__init__()
 
         self.model_config = model_config
         self.dtype = dtype
+        self.model_version = model_version
 
         self.register_weight(RegisteredWeightItem(
             "wte",
@@ -149,20 +153,22 @@ class LlamaWeight(WeightBase):
             (self.model_config.vocab_size, self.model_config.hidden_size),
             self.dtype
         ))
-        # Llama 1~3
-        # self.register_weight(RegisteredWeightItem(
-        #     "lm_head",
-        #     "lm_head.weight",
-        #     (self.model_config.vocab_size, self.model_config.hidden_size),
-        #     self.dtype
-        # ))
-        # Llama 3.1+
-        self.register_weight(RegisteredWeightItem(
-            "lm_head",
-            "model.embed_tokens.weight",
-            (self.model_config.vocab_size, self.model_config.hidden_size),
-            self.dtype
-        ))
+
+        if model_version == "llama3.2":
+            self.register_weight(RegisteredWeightItem(
+                "lm_head",
+                "model.embed_tokens.weight",
+                (self.model_config.vocab_size, self.model_config.hidden_size),
+                self.dtype
+            ))
+        else:
+            self.register_weight(RegisteredWeightItem(
+                "lm_head",
+                "lm_head.weight",
+                (self.model_config.vocab_size, self.model_config.hidden_size),
+                self.dtype
+            ))
+
         self.register_weight(RegisteredWeightItem(
             "final_norm",
             "model.norm.weight",
@@ -172,7 +178,7 @@ class LlamaWeight(WeightBase):
 
         self.layers: list[LlamaTransformerLayerWeight] = []
         for i in range(self.model_config.num_layers):
-            layer = LlamaTransformerLayerWeight(i, self.model_config, self.dtype)
+            layer = LlamaTransformerLayerWeight(i, self.model_config, self.dtype, self.model_version)
             self.layers.append(layer)
 
     def _post_process_after_load(self, getter: callable):
@@ -184,11 +190,28 @@ def load_weights(
     model_config: LlamaModelConfig,
     dtype: torch.dtype,
     model_path: str,
-    use_dummy: bool = False
+    use_dummy: bool = False,
+    model_version: str = "auto"
 ) -> LlamaWeight:
     """
     Load weights from a given path
     """
+    if model_version == "auto":
+        config_path = os.path.join(model_path, "config.json")
+        if os.path.exists(config_path):
+            with open(config_path, "r", encoding="utf-8") as f:
+                config_data = json.load(f)
+                
+            # In Llama 3.2, rope_scaling is a dictionary
+            # TODO 1: Add more robust detection logic
+            # TODO 2: Add more model versions
+            if "rope_scaling" in config_data and isinstance(config_data["rope_scaling"], dict):
+                model_version = "llama3.2"
+            else:
+                model_version = "llama"
+        else:
+            model_version = "llama"
+
     if use_dummy:
         def weight_getter_dummy(item: RegisteredWeightItem):
             return torch.empty(item.shape, dtype=item.dtype, device="cuda").uniform_(-0.001, 0.001)
@@ -244,6 +267,6 @@ def load_weights(
                 return file[item.key].to(item.dtype)
             getter = weight_getter_real
 
-    weight = LlamaWeight(model_config, dtype)
+    weight = LlamaWeight(model_config, dtype, model_version)
     weight.load_weights(getter)
     return weight


### PR DESCRIPTION
## Basic Test:
1. offline mode: `python3 examples/offline.py --model-path ./models/Llama-3.2-1B`
![image](https://github.com/user-attachments/assets/30c8166b-9580-4f70-a36c-2baf7ed1eafb)
2. online mode: `python3 examples/online.py --model-path ./models/Llama-3.2-1B`
![image](https://github.com/user-attachments/assets/02e66a52-efb8-4586-963c-60ecadb66699)
3. api_server: `python3 swiftllm/server/api_server.py --model-path ./models/Llama-3.2-1B/ --host 0.0.0.0 --port 8082`
![image](https://github.com/user-attachments/assets/dba819bc-d3ae-4712-8e12-3bcd45505cd3)

> The 3B model is not supported due to its hidden layer dimension of 3072
